### PR TITLE
Aspect ratio corrected prints & screenshots, updates builders

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: true
 
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-15-intel, macos-latest]
         build_type: [Release]
         include:
           - os: windows-latest

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -28,7 +28,7 @@ jobs:
           - os: macos-latest
             c_compiler: clang
             cpp_compiler: clang++
-          - os: macos-13
+          - os: macos-15-intel
             c_compiler: clang
             cpp_compiler: clang++
 

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -56,7 +56,7 @@ jobs:
         # Update MSYS2 installation through pacman
         #update: # optional
         # After installation and/or update, install additional packages through pacman
-        install: mingw-w64-x86_64-toolchain mingw-w64-x86_64-cmake mingw-w64-x86_64-SDL2 mingw-w64-SDL2_image mingw-w64-x86_64-boost
+        install: mingw-w64-x86_64-toolchain mingw-w64-x86_64-cmake mingw-w64-x86_64-SDL2 mingw-w64-x86_64-SDL2_image mingw-w64-x86_64-boost
         # After installation and/or update, install additional packages through pacboy
         #pacboy: # optional
         # Retrieve and extract base installation from upstream GitHub Releases

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -118,5 +118,5 @@ jobs:
     - name: Upload Artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ matrix.os == 'macos-13' && 'macos-intel' || matrix.os == 'macos-latest' && 'macos-arm64' || matrix.os }}
+        name: ${{ matrix.os == 'macos-15-intel' && 'macos-intel' || matrix.os == 'macos-latest' && 'macos-arm64' || matrix.os }}
         path: ${{ steps.strings.outputs.build-output-dir }}/dist/

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -38,12 +38,12 @@ jobs:
     - name: Dependencies (MacOS)
       if: startsWith(matrix.os, 'macos-')
       shell: bash
-      run: brew install sdl2 boost
+      run: brew install sdl2 sdl2_image boost
 
     - name: Dependencies (Ubuntu)
       if: startsWith(matrix.os, 'ubuntu-')
       shell: bash
-      run: sudo apt update && sudo apt install -y libsdl2-dev libboost-all-dev cmake
+      run: sudo apt update && sudo apt install -y libsdl2-dev libsdl2-image-dev libboost-all-dev cmake
 
     - name: Dependencies (Windows)
       uses: msys2/setup-msys2@v2
@@ -56,7 +56,7 @@ jobs:
         # Update MSYS2 installation through pacman
         #update: # optional
         # After installation and/or update, install additional packages through pacman
-        install: mingw-w64-x86_64-toolchain mingw-w64-x86_64-cmake mingw-w64-x86_64-SDL2 mingw-w64-x86_64-boost
+        install: mingw-w64-x86_64-toolchain mingw-w64-x86_64-cmake mingw-w64-x86_64-SDL2 mingw-w64-SDL2_image mingw-w64-x86_64-boost
         # After installation and/or update, install additional packages through pacboy
         #pacboy: # optional
         # Retrieve and extract base installation from upstream GitHub Releases

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 .vs/
 .vscode/
+.idea/
 out/
 build/
+cmake-build-*/
 CMakeSettings.json
 
 # MacOS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ set (SDL_STATIC ON CACHE BOOL "" FORCE)
 set (SDL_SHARED OFF CACHE BOOL "" FORCE)
 set (SDL_TEST OFF CACHE BOOL "" FORCE)
 find_package(SDL2 REQUIRED)
+find_package(SDL2_image REQUIRED)
 include_directories(LoopyMSE PRIVATE ${SDL2_INCLUDE_DIRS})
 
 set (DIST_DIR ${CMAKE_BINARY_DIR}/dist)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ set (CMAKE_CXX_STANDARD_REQUIRED ON)
 set (CMAKE_CXX_EXTENSIONS OFF)
 
 project (LoopyMSE LANGUAGES C CXX ASM)
-set (PROJECT_VERSION 0.5.1)
+set (PROJECT_VERSION 0.5.2)
 set (PROJECT_DESCRIPTION "Loopy My Seal Emulator")
 set (PROJECT_HOMEPAGE_URL "https://github.com/LoopyMSE/LoopyMSE")
 set (PROJECT_ORG "LoopyMSE")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,12 +7,12 @@ set (CMAKE_CXX_EXTENSIONS OFF)
 project (LoopyMSE LANGUAGES C CXX ASM)
 set (PROJECT_VERSION 0.5.1)
 set (PROJECT_DESCRIPTION "Loopy My Seal Emulator")
-set (PROJECT_HOMEPAGE_URL "https://github.com/PSI-Rockin/LoopyMSE")
-set (PROJECT_ORG "PSI")
+set (PROJECT_HOMEPAGE_URL "https://github.com/LoopyMSE/LoopyMSE")
+set (PROJECT_ORG "LoopyMSE")
 
 string(REPLACE "/DNDEBUG" "" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
 
-cmake_policy(SET CMP0167 NEW)
+#cmake_policy(SET CMP0167 NEW)
 
 # Boost program_options package, statically linked
 set(Boost_USE_STATIC_LIBS ON CACHE BOOL "" FORCE)

--- a/assets/loopymse.ini
+++ b/assets/loopymse.ini
@@ -41,4 +41,5 @@ pad_r1=rightshoulder
 
 [printer]
 image_type=bmp
+correct_aspect_ratio=true
 view_command=(OPEN)

--- a/assets/loopymse.ini
+++ b/assets/loopymse.ini
@@ -7,8 +7,8 @@ crop_overscan=true
 antialias=true
 start_in_fullscreen=false
 int_scale=4
-# Valid image types are: bmp
-screenshot_image_type=bmp
+# Valid image types are: bmp, jpg, png
+screenshot_image_type=png
 
 [keyboard-map]
 pad_up=up
@@ -39,6 +39,6 @@ pad_l1=leftshoulder
 pad_r1=rightshoulder
 
 [printer]
-image_type=bmp
+image_type=png
 correct_aspect_ratio=true
 view_command=(OPEN)

--- a/assets/loopymse.ini
+++ b/assets/loopymse.ini
@@ -7,7 +7,6 @@ crop_overscan=true
 antialias=true
 start_in_fullscreen=false
 int_scale=4
-capture_mouse=false
 # Valid image types are: bmp
 screenshot_image_type=bmp
 

--- a/assets/loopymse.ini
+++ b/assets/loopymse.ini
@@ -7,6 +7,7 @@ crop_overscan=true
 antialias=true
 start_in_fullscreen=false
 int_scale=4
+capture_mouse=false
 # Valid image types are: bmp
 screenshot_image_type=bmp
 

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -1,6 +1,4 @@
 add_library (common STATIC
 			 "bswp.cpp"
 			 "bswp.h"
-			 "imgwriter.cpp"
-			 "imgwriter.h"
 			 "wordops.h")

--- a/src/core/config.h
+++ b/src/core/config.h
@@ -27,6 +27,7 @@ struct EmulatorOpts
 	fs::path image_save_directory;
 	int screenshot_image_type;
 	int printer_image_type;
+	bool printer_correct_aspect_ratio;
 	std::string printer_view_command;
 };
 

--- a/src/core/loopy_io.cpp
+++ b/src/core/loopy_io.cpp
@@ -197,6 +197,7 @@ void set_controller_plugged(bool plugged_pad, bool plugged_mouse)
 		state.mouse.counter_x = 0;
 		state.mouse.counter_y = 0;
 	}
+	Log::debug("Controller port devices set, PAD=%d MOUSE=%d", state.pad.plugged, state.mouse.plugged);
 }
 
 void update_print_temp()

--- a/src/core/loopy_io.cpp
+++ b/src/core/loopy_io.cpp
@@ -197,7 +197,6 @@ void set_controller_plugged(bool plugged_pad, bool plugged_mouse)
 		state.mouse.counter_x = 0;
 		state.mouse.counter_y = 0;
 	}
-	Log::debug("Controller port devices set, PAD=%d MOUSE=%d", state.pad.plugged, state.mouse.plugged);
 }
 
 void update_print_temp()

--- a/src/input/input.cpp
+++ b/src/input/input.cpp
@@ -1,5 +1,6 @@
 #include "input/input.h"
 
+#include <SDL_mouse.h>
 #include <core/loopy_io.h>
 
 #include <unordered_map>
@@ -47,12 +48,11 @@ void set_key_state(int key, bool pressed)
 
 void set_mouse_button_state(int button, bool pressed)
 {
-	// TODO: replace the hardcoded 1 and 3 with SDL constants or bindings?
-	if (button == 1)
+	if (button == SDL_BUTTON_LEFT)
 	{
 		LoopyIO::update_mouse_buttons(MOUSE_L, pressed);
 	}
-	if (button == 3)
+	if (button == SDL_BUTTON_RIGHT)
 	{
 		LoopyIO::update_mouse_buttons(MOUSE_R, pressed);
 	}

--- a/src/input/input.cpp
+++ b/src/input/input.cpp
@@ -1,6 +1,5 @@
 #include "input/input.h"
 
-#include <SDL_mouse.h>
 #include <core/loopy_io.h>
 
 #include <unordered_map>
@@ -10,6 +9,7 @@ namespace Input
 
 static std::unordered_map<int, PadButton> key_bindings;
 static std::unordered_map<int, PadButton> controller_bindings;
+static std::unordered_map<int, MouseButton> mouse_bindings;
 
 void initialize()
 {
@@ -48,14 +48,14 @@ void set_key_state(int key, bool pressed)
 
 void set_mouse_button_state(int button, bool pressed)
 {
-	if (button == SDL_BUTTON_LEFT)
+	auto binding = mouse_bindings.find(button);
+	if (binding == mouse_bindings.end())
 	{
-		LoopyIO::update_mouse_buttons(MOUSE_L, pressed);
+		return;
 	}
-	if (button == SDL_BUTTON_RIGHT)
-	{
-		LoopyIO::update_mouse_buttons(MOUSE_R, pressed);
-	}
+
+	MouseButton mouse_button = binding->second;
+	LoopyIO::update_mouse_buttons(mouse_button, pressed);
 }
 
 void move_mouse(int delta_x, int delta_y)
@@ -71,6 +71,11 @@ void add_key_binding(int code, PadButton pad_button)
 void add_controller_binding(int code, PadButton pad_button)
 {
 	controller_bindings.emplace(code, pad_button);
+}
+
+void add_mouse_binding(int code, MouseButton mouse_button)
+{
+	mouse_bindings.emplace(code, mouse_button);
 }
 
 }  // namespace Input

--- a/src/input/input.h
+++ b/src/input/input.h
@@ -37,5 +37,6 @@ void move_mouse(int delta_x, int delta_y);
 
 void add_key_binding(int key, PadButton pad_button);
 void add_controller_binding(int key, PadButton pad_button);
+void add_mouse_binding(int code, MouseButton mouse_button);
 
-}
+}  // namespace Input

--- a/src/printer/printer.cpp
+++ b/src/printer/printer.cpp
@@ -1,9 +1,9 @@
 #include "printer/printer.h"
 
-#include <sdl/imgwriter.h>
 #include <core/sh2/sh2_bus.h>
 #include <core/sh2/sh2_local.h>
 #include <log/log.h>
+#include <sdl/imgwriter.h>
 
 #include <algorithm>
 #include <cmath>
@@ -35,6 +35,7 @@ constexpr static int PRINT_STATUS_OVERHEAT = 5;
 
 static fs::path output_dir;
 static int output_type;
+static float print_aspect_ratio = 0;
 static std::string view_command;
 
 static fs::path last_printed_path;
@@ -204,12 +205,12 @@ bool print_hook(uint32_t addr)
 			{
 				std::vector<uint8_t> data_doubled = double_pixel_data<uint8_t>(data, width, height);
 				print_success = imagew::save_image_8bpp(
-					output_type, print_path, width * 2, height * 2, &data_doubled[0], 256, palette
+					output_type, print_path, width * 2, height * 2, &data_doubled[0], 256, palette, false, print_aspect_ratio
 				);
 			}
 			else
 			{
-				print_success = imagew::save_image_8bpp(output_type, print_path, width, height, &data[0], 256, palette);
+				print_success = imagew::save_image_8bpp(output_type, print_path, width, height, &data[0], 256, palette, false, print_aspect_ratio);
 			}
 		}
 		if (pixel_format == 1)
@@ -225,11 +226,11 @@ bool print_hook(uint32_t addr)
 			{
 				std::vector<uint16_t> data_doubled = double_pixel_data<uint16_t>(data, width, height);
 				print_success =
-					imagew::save_image_16bpp(output_type, print_path, width * 2, height * 2, &data_doubled[0]);
+					imagew::save_image_16bpp(output_type, print_path, width * 2, height * 2, &data_doubled[0], false, print_aspect_ratio);
 			}
 			else
 			{
-				print_success = imagew::save_image_16bpp(output_type, print_path, width, height, &data[0]);
+				print_success = imagew::save_image_16bpp(output_type, print_path, width, height, &data[0], false, print_aspect_ratio);
 			}
 		}
 
@@ -285,6 +286,7 @@ void initialize(Config::SystemInfo& config)
 {
 	output_dir = config.emulator.image_save_directory;
 	output_type = config.emulator.printer_image_type;
+	print_aspect_ratio = config.emulator.printer_correct_aspect_ratio ? imagew::LOOPY_SEAL_PAR : 0;
 
 	view_command = config.emulator.printer_view_command;
 	view_command.erase(

--- a/src/printer/printer.cpp
+++ b/src/printer/printer.cpp
@@ -205,12 +205,15 @@ bool print_hook(uint32_t addr)
 			{
 				std::vector<uint8_t> data_doubled = double_pixel_data<uint8_t>(data, width, height);
 				print_success = imagew::save_image_8bpp(
-					output_type, print_path, width * 2, height * 2, &data_doubled[0], 256, palette, false, print_aspect_ratio
+					output_type, print_path, width * 2, height * 2, &data_doubled[0], 256, palette, false,
+					print_aspect_ratio
 				);
 			}
 			else
 			{
-				print_success = imagew::save_image_8bpp(output_type, print_path, width, height, &data[0], 256, palette, false, print_aspect_ratio);
+				print_success = imagew::save_image_8bpp(
+					output_type, print_path, width, height, &data[0], 256, palette, false, print_aspect_ratio
+				);
 			}
 		}
 		if (pixel_format == 1)
@@ -225,12 +228,15 @@ bool print_hook(uint32_t addr)
 			if (pixel_double == 1)
 			{
 				std::vector<uint16_t> data_doubled = double_pixel_data<uint16_t>(data, width, height);
-				print_success =
-					imagew::save_image_16bpp(output_type, print_path, width * 2, height * 2, &data_doubled[0], false, print_aspect_ratio);
+				print_success = imagew::save_image_16bpp(
+					output_type, print_path, width * 2, height * 2, &data_doubled[0], false, print_aspect_ratio
+				);
 			}
 			else
 			{
-				print_success = imagew::save_image_16bpp(output_type, print_path, width, height, &data[0], false, print_aspect_ratio);
+				print_success = imagew::save_image_16bpp(
+					output_type, print_path, width, height, &data[0], false, print_aspect_ratio
+				);
 			}
 		}
 

--- a/src/printer/printer.cpp
+++ b/src/printer/printer.cpp
@@ -292,7 +292,7 @@ void initialize(Config::SystemInfo& config)
 {
 	output_dir = config.emulator.image_save_directory;
 	output_type = config.emulator.printer_image_type;
-	print_aspect_ratio = config.emulator.printer_correct_aspect_ratio ? imagew::LOOPY_SEAL_PAR : 0;
+	print_aspect_ratio = config.emulator.printer_correct_aspect_ratio ? imagew::LOOPY_SEAL_ASPECT : 0;
 
 	view_command = config.emulator.printer_view_command;
 	view_command.erase(

--- a/src/printer/printer.h
+++ b/src/printer/printer.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <cstdint>
-
 #include <core/config.h>
+
+#include <cstdint>
 
 namespace Printer
 {
@@ -13,4 +13,4 @@ void shutdown();
 bool motor_move_hook(uint32_t addr);
 bool printer_hook(uint32_t addr);
 
-}
+}  // namespace Printer

--- a/src/sdl/CMakeLists.txt
+++ b/src/sdl/CMakeLists.txt
@@ -1,52 +1,54 @@
-add_executable (LoopyMSE
-				"config.h"
-				"options.h"
-				"options.cpp"
-				"main.cpp")
+add_executable(LoopyMSE
+        "config.h"
+        "options.h"
+        "options.cpp"
+        "imgwriter.h"
+        "imgwriter.cpp"
+        "main.cpp")
 
-target_compile_definitions(LoopyMSE PRIVATE 
-	PROJECT_NAME="${PROJECT_NAME}"
-	PROJECT_ORG="${PROJECT_ORG}"
-	PROJECT_DESCRIPTION="${PROJECT_DESCRIPTION}"
-	PROJECT_VERSION="${PROJECT_VERSION}"
+target_compile_definitions(LoopyMSE PRIVATE
+        PROJECT_NAME="${PROJECT_NAME}"
+        PROJECT_ORG="${PROJECT_ORG}"
+        PROJECT_DESCRIPTION="${PROJECT_DESCRIPTION}"
+        PROJECT_VERSION="${PROJECT_VERSION}"
 )
 
 if (WIN32)
-	target_sources(LoopyMSE PRIVATE "windows.rc")
-	target_link_options(LoopyMSE PRIVATE -mwindows -static)
-endif()
+    target_sources(LoopyMSE PRIVATE "windows.rc")
+    target_link_options(LoopyMSE PRIVATE -mwindows -static)
+endif ()
 
 if (APPLE)
-	set(CMAKE_MACOSX_BUNDLE ON)
+    set(CMAKE_MACOSX_BUNDLE ON)
 
-	set(BUNDLE_RESOURCES_DIR "LoopyMSE.app/Contents/Resources")
-	set(ICON_NAME "macos.icns")
-	set(ICON_PATH ${CMAKE_CURRENT_SOURCE_DIR}/${ICON_NAME})
-	set_source_files_properties(${ICON_PATH} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
-	file(COPY ${ICON_PATH} DESTINATION ${BUNDLE_RESOURCES_DIR})
-	
-	file(GLOB RESOURCE_FILES "${ASSETS_DIR}/*")
-	file(COPY ${RESOURCE_FILES} DESTINATION ${BUNDLE_RESOURCES_DIR})
+    set(BUNDLE_RESOURCES_DIR "LoopyMSE.app/Contents/Resources")
+    set(ICON_NAME "macos.icns")
+    set(ICON_PATH ${CMAKE_CURRENT_SOURCE_DIR}/${ICON_NAME})
+    set_source_files_properties(${ICON_PATH} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
+    file(COPY ${ICON_PATH} DESTINATION ${BUNDLE_RESOURCES_DIR})
 
-	file(COPY "${ASSETS_DIR}/README.md" DESTINATION ${DIST_DIR})
+    file(GLOB RESOURCE_FILES "${ASSETS_DIR}/*")
+    file(COPY ${RESOURCE_FILES} DESTINATION ${BUNDLE_RESOURCES_DIR})
 
-	set_target_properties(LoopyMSE PROPERTIES MACOSX_BUNDLE ON)
-	set_target_properties(LoopyMSE PROPERTIES MACOSX_BUNDLE_ICONFILE ${ICON_NAME})
-	set_target_properties(LoopyMSE PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/Info.plist)
-endif()
+    file(COPY "${ASSETS_DIR}/README.md" DESTINATION ${DIST_DIR})
 
-target_link_libraries (LoopyMSE PRIVATE core SDL2::SDL2-static Boost::program_options)
+    set_target_properties(LoopyMSE PROPERTIES MACOSX_BUNDLE ON)
+    set_target_properties(LoopyMSE PROPERTIES MACOSX_BUNDLE_ICONFILE ${ICON_NAME})
+    set_target_properties(LoopyMSE PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/Info.plist)
+endif ()
+
+target_link_libraries(LoopyMSE PRIVATE core SDL2::SDL2-static Boost::program_options)
 
 # INSTALLATION
 
-install (TARGETS LoopyMSE
-		RUNTIME DESTINATION ${DIST_DIR}
-		BUNDLE DESTINATION ${DIST_DIR})
+install(TARGETS LoopyMSE
+        RUNTIME DESTINATION ${DIST_DIR}
+        BUNDLE DESTINATION ${DIST_DIR})
 
 if (WIN32)
-install (DIRECTORY ${ASSETS_DIR}/
-		DESTINATION ${DIST_DIR}
-		FILES_MATCHING PATTERN "*")
-install (CODE "file(TOUCH \"${DIST_DIR}/__PLACE_BIOS.BIN_HERE__\")")
-install (CODE "file(TOUCH \"${DIST_DIR}/__PLACE_SOUNDBIOS.BIN_HERE__\")")
-endif()
+    install(DIRECTORY ${ASSETS_DIR}/
+            DESTINATION ${DIST_DIR}
+            FILES_MATCHING PATTERN "*")
+    install(CODE "file(TOUCH \"${DIST_DIR}/__PLACE_BIOS.BIN_HERE__\")")
+    install(CODE "file(TOUCH \"${DIST_DIR}/__PLACE_SOUNDBIOS.BIN_HERE__\")")
+endif ()

--- a/src/sdl/CMakeLists.txt
+++ b/src/sdl/CMakeLists.txt
@@ -37,7 +37,7 @@ if (APPLE)
     set_target_properties(LoopyMSE PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/Info.plist)
 endif ()
 
-target_link_libraries(LoopyMSE PRIVATE core SDL2::SDL2-static Boost::program_options)
+target_link_libraries(LoopyMSE PRIVATE core SDL2::SDL2-static SDL2_image::SDL2_image-static Boost::program_options)
 
 # INSTALLATION
 

--- a/src/sdl/imgwriter.cpp
+++ b/src/sdl/imgwriter.cpp
@@ -12,6 +12,8 @@
 namespace SDL::ImageWriter
 {
 
+constexpr double PRINT_ASPECT_CORRECTION_PRESCALE = 4;
+
 int parse_image_type(std::string type, int default_)
 {
 	std::transform(type.begin(), type.end(), type.begin(), [](unsigned char c) { return std::tolower(c); });
@@ -24,8 +26,8 @@ int parse_image_type(std::string type, int default_)
 
 fs::path image_extension(int image_type)
 {
-	if (image_type == IMAGE_TYPE_BMP) return fs::path(".bmp");
-	return fs::path("");
+	if (image_type == IMAGE_TYPE_BMP) return {".bmp"};
+	return {""};
 }
 
 fs::path make_unique_name(std::string prefix, std::string suffix)
@@ -39,109 +41,40 @@ fs::path make_unique_name(std::string prefix, std::string suffix)
 	return prefix + timestamp_buffer + "_" + std::to_string(unique_number++) + suffix;
 }
 
-bool write_bmp(fs::path path, uint32_t width, uint32_t height, uint32_t data[], bool transparent)
+bool write_image(
+	int image_type, fs::path path, uint32_t width, uint32_t height, uint32_t pixels_argb[], bool _transparent,
+	double correct_aspect
+)
 {
-	SDL_Surface* surf =
-		SDL_CreateRGBSurfaceWithFormatFrom(data, (int)width, (int)height, 32, (int)width * 4, SDL_PIXELFORMAT_ARGB8888);
-	return 0 == SDL_SaveBMP(surf, path.string().c_str());
+	SDL_Surface* surf = SDL_CreateRGBSurfaceWithFormatFrom(
+		pixels_argb, (int)width, (int)height, 32, (int)width * 4, SDL_PIXELFORMAT_ARGB8888
+	);
 
-	std::ofstream bmp_file(path, std::ios::binary);
-	if (!bmp_file.is_open()) return false;
-
-	//BMP header
-	const char* SIGNATURE = "BM";
-	bmp_file.write(SIGNATURE, 2);
-
-	uint32_t head_size = 14;
-	uint32_t info_size = transparent ? 108 : 40;
-	uint32_t data_size_per_row = transparent ? (width * 4) : (width * 3);
-	uint32_t padding_per_row = (4 - (data_size_per_row % 4)) % 4;
-	uint32_t data_size = (data_size_per_row + padding_per_row) * height;
-
-	uint32_t file_size = head_size + info_size + data_size;
-	bmp_file.write((char*)&file_size, 4);
-
-	uint32_t reserved = 0;
-	bmp_file.write((char*)&reserved, 4);
-
-	uint32_t data_offs = head_size + info_size;
-	bmp_file.write((char*)&data_offs, 4);
-
-	//DIB header
-	bmp_file.write((char*)&info_size, 4);
-
-	bmp_file.write((char*)&width, 4);
-	bmp_file.write((char*)&height, 4);
-
-	uint16_t planes = 1;
-	bmp_file.write((char*)&planes, 2);
-
-	uint16_t bpp = transparent ? 32 : 24;
-	bmp_file.write((char*)&bpp, 2);
-
-	uint32_t compression = transparent ? 3 : 0;	 // BI_BITFIELDS or BI_RGB
-	bmp_file.write((char*)&compression, 4);
-
-	bmp_file.write((char*)&data_size, 4);
-
-	uint32_t pixels_per_metre = 2835;  // 72DPI
-	bmp_file.write((char*)&pixels_per_metre, 4);
-	bmp_file.write((char*)&pixels_per_metre, 4);
-
-	uint32_t num_colors = 0;
-	bmp_file.write((char*)&num_colors, 4);
-	bmp_file.write((char*)&num_colors, 4);
-
-	if (transparent)
+	if (correct_aspect > 0)
 	{
-		uint32_t bitmask_r = 0xFF << 16;
-		uint32_t bitmask_g = 0xFF << 8;
-		uint32_t bitmask_b = 0xFF;
-		uint32_t bitmask_a = 0xFF << 24;
-		bmp_file.write((char*)&bitmask_r, 4);
-		bmp_file.write((char*)&bitmask_g, 4);
-		bmp_file.write((char*)&bitmask_b, 4);
-		bmp_file.write((char*)&bitmask_a, 4);
+		double scaled_height = height * PRINT_ASPECT_CORRECTION_PRESCALE;
+		double scaled_width = scaled_height * correct_aspect;
+		SDL_Surface* scaled =
+			SDL_CreateRGBSurfaceWithFormat(0, (int)scaled_width, (int)scaled_height, 32, SDL_PIXELFORMAT_ARGB8888);
+		// No AA, sharper. Alternatively SDL_SoftStretchLinear for bilinear
+		SDL_BlitScaled(surf, nullptr, scaled, nullptr);
 
-		const char* color_space = "sRGB";
-		bmp_file.write((char*)&color_space, 4);
-		bmp_file.write((char*)&reserved, 4);
-		bmp_file.write((char*)&reserved, 4);
-		bmp_file.write((char*)&reserved, 4);
-		bmp_file.write((char*)&reserved, 4);
-		bmp_file.write((char*)&reserved, 4);
-		bmp_file.write((char*)&reserved, 4);
-		bmp_file.write((char*)&reserved, 4);
-		bmp_file.write((char*)&reserved, 4);
-		bmp_file.write((char*)&reserved, 4);
-		bmp_file.write((char*)&reserved, 4);
-		bmp_file.write((char*)&reserved, 4);
-		bmp_file.write((char*)&reserved, 4);
+		Log::debug("Rescaling image from %dx%d -> %dx%d", surf->w, surf->h, scaled->w, scaled->h);
+
+		SDL_FreeSurface(surf);
+		surf = scaled;
 	}
 
-	for (int y = 0; y < height; y++)
+	bool success = false;
+	if (image_type == IMAGE_TYPE_BMP)
 	{
-		int flipped_y = height - y - 1;
-		for (int x = 0; x < width; x++)
-		{
-			//Write B,G,R,A or B,G,R (assumes system is little-endian!)
-			uint32_t pixel_argb = data[flipped_y * width + x];
-			bmp_file.write((char*)&pixel_argb, transparent ? 4 : 3);
-		}
-		if (padding_per_row > 0)
-		{
-			bmp_file.write((char*)&reserved, padding_per_row);
-		}
+		success = 0 == SDL_SaveBMP(surf, path.string().c_str());
 	}
 
-	bmp_file.close();
-	return true;
-}
+	// Should not free the pixel data since we created it with a *From
+	SDL_FreeSurface(surf);
 
-bool write_image(int image_type, fs::path path, uint32_t width, uint32_t height, uint32_t data[], bool transparent)
-{
-	if (image_type == IMAGE_TYPE_BMP) return write_bmp(path, width, height, data, transparent);
-	return false;
+	return success;
 }
 
 static inline uint32_t color_16bpp_to_argb(uint16_t c)
@@ -153,7 +86,10 @@ static inline uint32_t color_16bpp_to_argb(uint16_t c)
 	return (a << 24) | (r << 16) | (g << 8) | b;
 }
 
-bool save_image_16bpp(int image_type, fs::path path, uint32_t width, uint32_t height, uint16_t data[], bool transparent)
+bool save_image_16bpp(
+	int image_type, fs::path path, uint32_t width, uint32_t height, uint16_t data[], bool transparent,
+	double correct_aspect
+)
 {
 	unsigned int num_pixels = width * height;
 	uint32_t data_argb[num_pixels];
@@ -165,12 +101,12 @@ bool save_image_16bpp(int image_type, fs::path path, uint32_t width, uint32_t he
 		data_argb[i] = color_16bpp_to_argb(data[i] | alpha_set);
 	}
 
-	return write_image(image_type, path, width, height, data_argb, transparent);
+	return write_image(image_type, path, width, height, data_argb, transparent, correct_aspect);
 }
 
 bool save_image_8bpp(
 	int image_type, fs::path path, uint32_t width, uint32_t height, uint8_t data[], uint32_t num_colors,
-	uint16_t palette[], bool transparent
+	uint16_t palette[], bool transparent, double correct_aspect
 )
 {
 	unsigned int num_pixels = width * height;
@@ -183,7 +119,7 @@ bool save_image_8bpp(
 		data_16bpp[i] = palette[pixel];
 	}
 
-	return save_image_16bpp(image_type, path, width, height, data_16bpp, transparent);
+	return save_image_16bpp(image_type, path, width, height, data_16bpp, transparent, correct_aspect);
 }
 
 }  // namespace SDL::ImageWriter

--- a/src/sdl/imgwriter.cpp
+++ b/src/sdl/imgwriter.cpp
@@ -1,6 +1,6 @@
 #include "imgwriter.h"
 
-#include <SDL_image.h>
+#include <SDL2/SDL_image.h>
 #include <log/log.h>
 
 #include <algorithm>
@@ -11,9 +11,8 @@
 
 namespace SDL::ImageWriter
 {
-
-constexpr int JPG_QUALITY = 90;
-constexpr double PRINT_ASPECT_CORRECTION_PRESCALE = 4;
+const int JPG_QUALITY = 90;
+const double PRINT_ASPECT_CORRECTION_PRESCALE = 4;
 
 int parse_image_type(std::string type, int default_)
 {

--- a/src/sdl/imgwriter.h
+++ b/src/sdl/imgwriter.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <string>
 #include <filesystem>
+#include <string>
 
 namespace fs = std::filesystem;
 
@@ -11,12 +11,21 @@ namespace SDL::ImageWriter
 constexpr static int IMAGE_TYPE_BMP = 1;
 constexpr static int IMAGE_TYPE_DEFAULT = IMAGE_TYPE_BMP;
 
+constexpr double LOOPY_SEAL_PAR = 42.0 / 32.0;
+constexpr double LOOPY_SCREEN_PAR = 4.0 / 3.0;
+
 int parse_image_type(std::string type, int default_);
 
 fs::path image_extension(int image_type);
 fs::path make_unique_name(std::string prefix = "", std::string suffix = "");
 
-bool save_image_16bpp(int image_type, fs::path path, uint32_t width, uint32_t height, uint16_t data[], bool transparent = false);
-bool save_image_8bpp(int image_type, fs::path path, uint32_t width, uint32_t height, uint8_t data[], uint32_t num_colors, uint16_t palette[], bool transparent = false);
+bool save_image_16bpp(
+	int image_type, fs::path path, uint32_t width, uint32_t height, uint16_t data[], bool transparent = false,
+	double correct_aspect = 0
+);
+bool save_image_8bpp(
+	int image_type, fs::path path, uint32_t width, uint32_t height, uint8_t data[], uint32_t num_colors,
+	uint16_t palette[], bool transparent = false, double correct_aspect = 0
+);
 
-}
+}  // namespace SDL::ImageWriter

--- a/src/sdl/imgwriter.h
+++ b/src/sdl/imgwriter.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <SDL.h>
+
 #include <filesystem>
 #include <string>
 
@@ -8,17 +10,24 @@ namespace fs = std::filesystem;
 namespace SDL::ImageWriter
 {
 
-constexpr static int IMAGE_TYPE_BMP = 1;
-constexpr static int IMAGE_TYPE_DEFAULT = IMAGE_TYPE_BMP;
+constexpr int IMAGE_TYPE_BMP = 1;
+constexpr int IMAGE_TYPE_PNG = 2;
+constexpr int IMAGE_TYPE_JPG = 3;
+constexpr int IMAGE_TYPE_DEFAULT = IMAGE_TYPE_PNG;
 
 constexpr double LOOPY_SEAL_PAR = 42.0 / 32.0;
 constexpr double LOOPY_SCREEN_PAR = 4.0 / 3.0;
 
-int parse_image_type(std::string type, int default_);
+int parse_image_type(std::string type, int _default);
 
 fs::path image_extension(int image_type);
 fs::path make_unique_name(std::string prefix = "", std::string suffix = "");
 
+bool save_surface(int image_type, fs::path path, SDL_Surface* surf);
+bool save_image_32bpp(
+	int image_type, fs::path path, uint32_t width, uint32_t height, uint32_t data[], bool transparent = false,
+	double correct_aspect = 0
+);
 bool save_image_16bpp(
 	int image_type, fs::path path, uint32_t width, uint32_t height, uint16_t data[], bool transparent = false,
 	double correct_aspect = 0

--- a/src/sdl/imgwriter.h
+++ b/src/sdl/imgwriter.h
@@ -5,7 +5,7 @@
 
 namespace fs = std::filesystem;
 
-namespace Common::ImageWriter
+namespace SDL::ImageWriter
 {
 
 constexpr static int IMAGE_TYPE_BMP = 1;

--- a/src/sdl/imgwriter.h
+++ b/src/sdl/imgwriter.h
@@ -10,13 +10,13 @@ namespace fs = std::filesystem;
 namespace SDL::ImageWriter
 {
 
-constexpr int IMAGE_TYPE_BMP = 1;
-constexpr int IMAGE_TYPE_PNG = 2;
-constexpr int IMAGE_TYPE_JPG = 3;
-constexpr int IMAGE_TYPE_DEFAULT = IMAGE_TYPE_PNG;
+const int IMAGE_TYPE_BMP = 1;
+const int IMAGE_TYPE_PNG = 2;
+const int IMAGE_TYPE_JPG = 3;
+const int IMAGE_TYPE_DEFAULT = IMAGE_TYPE_PNG;
 
-constexpr double LOOPY_SEAL_PAR = 42.0 / 32.0;
-constexpr double LOOPY_SCREEN_PAR = 4.0 / 3.0;
+const double LOOPY_SEAL_ASPECT = 8.0 / 7.0;
+const double LOOPY_SCREEN_ASPECT = 4.0 / 3.0;
 
 int parse_image_type(std::string type, int _default);
 

--- a/src/sdl/main.cpp
+++ b/src/sdl/main.cpp
@@ -1,7 +1,6 @@
 #include <SDL2/SDL.h>
 #include <common/bswp.h>
 #include <core/config.h>
-#include <core/loopy_io.h>
 #include <core/system.h>
 #include <input/input.h>
 #include <log/log.h>

--- a/src/sdl/main.cpp
+++ b/src/sdl/main.cpp
@@ -295,6 +295,10 @@ void initialize(Options::Args& args)
 		// Nonfatal: continue without the mappings
 	}
 	open_first_controller();
+
+	// Mouse mappings don't really need configuration
+	Input::add_mouse_binding(SDL_BUTTON_LEFT, Input::MouseButton::MOUSE_L);
+	Input::add_mouse_binding(SDL_BUTTON_RIGHT, Input::MouseButton::MOUSE_R);
 }
 
 }  // namespace SDL

--- a/src/sdl/main.cpp
+++ b/src/sdl/main.cpp
@@ -158,12 +158,7 @@ void screenshot(int image_type, fs::path path)
 	SDL_GetRendererOutputSize(screen.renderer, &w, &h);
 	SDL_Surface* screenshot = SDL_CreateRGBSurfaceWithFormat(0, w, h, 32, SDL_PIXELFORMAT_RGB24);
 	SDL_RenderReadPixels(screen.renderer, nullptr, screenshot->format->format, screenshot->pixels, screenshot->pitch);
-
-	if (image_type == imagew::IMAGE_TYPE_BMP)
-	{
-		SDL_SaveBMP(screenshot, path.string().c_str());
-	}
-
+	imagew::save_surface(image_type, path, screenshot);
 	SDL_FreeSurface(screenshot);
 }
 

--- a/src/sdl/main.cpp
+++ b/src/sdl/main.cpp
@@ -62,7 +62,7 @@ void capture_mouse(bool cap)
 {
 	SDL_SetRelativeMouseMode(cap ? SDL_TRUE : SDL_FALSE);
 	mouse_captured = cap;
-	LoopyIO::set_controller_plugged(!cap, cap);
+	// LoopyIO::set_controller_plugged(!cap, cap);
 }
 
 bool is_mouse_captured()
@@ -415,6 +415,7 @@ int main(int argc, char** argv)
 	config.emulator.screenshot_image_type = args.screenshot_image_type;
 	config.emulator.printer_image_type = args.printer_image_type;
 	config.emulator.printer_view_command = args.printer_view_command;
+	config.emulator.printer_correct_aspect_ratio = args.printer_correct_aspect_ratio;
 
 	Log::set_level(args.verbose ? Log::VERBOSE : Log::INFO);
 

--- a/src/sdl/main.cpp
+++ b/src/sdl/main.cpp
@@ -1,8 +1,8 @@
 #include <SDL2/SDL.h>
 #include <common/bswp.h>
-#include <common/imgwriter.h>
 #include <core/config.h>
 #include <core/system.h>
+#include <sdl/imgwriter.h>
 #include <input/input.h>
 #include <log/log.h>
 #include <sound/sound.h>
@@ -15,12 +15,13 @@
 #include <iostream>
 
 #include "config.h"
+#include "core/loopy_io.h"
 #include "options.h"
 
 #define PRESCALE_FACTOR 4
 #define MAX_WINDOW_INT_SCALE 10
 
-namespace imagew = Common::ImageWriter;
+namespace imagew = SDL::ImageWriter;
 
 namespace SDL
 {
@@ -61,6 +62,8 @@ void capture_mouse(bool cap)
 {
 	SDL_SetRelativeMouseMode(cap ? SDL_TRUE : SDL_FALSE);
 	mouse_captured = cap;
+	// Not production ready?
+	LoopyIO::set_controller_plugged(!cap, cap);
 }
 
 bool is_mouse_captured()

--- a/src/sdl/main.cpp
+++ b/src/sdl/main.cpp
@@ -62,7 +62,6 @@ void capture_mouse(bool cap)
 {
 	SDL_SetRelativeMouseMode(cap ? SDL_TRUE : SDL_FALSE);
 	mouse_captured = cap;
-	// LoopyIO::set_controller_plugged(!cap, cap);
 }
 
 bool is_mouse_captured()
@@ -655,7 +654,7 @@ int main(int argc, char** argv)
 				{
 					Input::set_mouse_button_state(e.button.button, true);
 				}
-				else if (args.capture_mouse)
+				else
 				{
 					SDL::capture_mouse(true);
 				}

--- a/src/sdl/options.cpp
+++ b/src/sdl/options.cpp
@@ -5,12 +5,12 @@
 #include <fstream>
 #include <iostream>
 
-#include "common/imgwriter.h"
+#include "imgwriter.h"
 #include "input/input.h"
 #include "log/log.h"
 
 namespace po = boost::program_options;
-namespace imagew = Common::ImageWriter;
+namespace imagew = SDL::ImageWriter;
 
 namespace Options
 {

--- a/src/sdl/options.cpp
+++ b/src/sdl/options.cpp
@@ -151,7 +151,8 @@ bool parse_config(fs::path config_path, Args& args)
 		("emulator.correct_aspect_ratio", po::value<bool>()->default_value(true), "Stretch display pixels to 4:3")
 		("emulator.crop_overscan", po::value<bool>()->default_value(true), "Crop border and overscan areas")
 		("emulator.antialias", po::value<bool>()->default_value(true), "Apply AA (recommended when used with aspect ratio correction)")
-		("emulator.screenshot_image_type", po::value<std::string>()->default_value("bmp"), "Image file type for screenshots");
+		("emulator.screenshot_image_type", po::value<std::string>()->default_value("bmp"), "Image file type for screenshots")
+		("emulator.capture_mouse", po::value<bool>()->default_value(false), "Use the Loopy Mouse when clicking inside the focused window");
 
 	po::options_description printer_options("Printer");
 	printer_options.add_options()
@@ -180,10 +181,11 @@ bool parse_config(fs::path config_path, Args& args)
 		args.antialias = vm["emulator.antialias"].as<bool>();
 		args.crop_overscan = vm["emulator.crop_overscan"].as<bool>();
 		args.int_scale = vm["emulator.int_scale"].as<int>();
+		args.capture_mouse = vm["emulator.capture_mouse"].as<bool>();
+
 		args.screenshot_image_type = imagew::parse_image_type(
 			vm["emulator.screenshot_image_type"].as<std::string>(), imagew::IMAGE_TYPE_DEFAULT
 		);
-
 		args.printer_image_type =
 			imagew::parse_image_type(vm["printer.image_type"].as<std::string>(), imagew::IMAGE_TYPE_DEFAULT);
 		args.printer_view_command = vm["printer.view_command"].as<std::string>();

--- a/src/sdl/options.cpp
+++ b/src/sdl/options.cpp
@@ -151,8 +151,7 @@ bool parse_config(fs::path config_path, Args& args)
 		("emulator.correct_aspect_ratio", po::value<bool>()->default_value(true), "Stretch display pixels to 4:3")
 		("emulator.crop_overscan", po::value<bool>()->default_value(true), "Crop border and overscan areas")
 		("emulator.antialias", po::value<bool>()->default_value(true), "Apply AA (recommended when used with aspect ratio correction)")
-		("emulator.screenshot_image_type", po::value<std::string>()->default_value("bmp"), "Image file type for screenshots")
-		("emulator.capture_mouse", po::value<bool>()->default_value(false), "Use the Loopy Mouse when clicking inside the focused window");
+		("emulator.screenshot_image_type", po::value<std::string>()->default_value("bmp"), "Image file type for screenshots");
 
 	po::options_description printer_options("Printer");
 	printer_options.add_options()
@@ -182,7 +181,6 @@ bool parse_config(fs::path config_path, Args& args)
 		args.antialias = vm["emulator.antialias"].as<bool>();
 		args.crop_overscan = vm["emulator.crop_overscan"].as<bool>();
 		args.int_scale = vm["emulator.int_scale"].as<int>();
-		args.capture_mouse = vm["emulator.capture_mouse"].as<bool>();
 
 		args.screenshot_image_type = imagew::parse_image_type(
 			vm["emulator.screenshot_image_type"].as<std::string>(), imagew::IMAGE_TYPE_DEFAULT

--- a/src/sdl/options.cpp
+++ b/src/sdl/options.cpp
@@ -151,11 +151,11 @@ bool parse_config(fs::path config_path, Args& args)
 		("emulator.correct_aspect_ratio", po::value<bool>()->default_value(true), "Stretch display pixels to 4:3")
 		("emulator.crop_overscan", po::value<bool>()->default_value(true), "Crop border and overscan areas")
 		("emulator.antialias", po::value<bool>()->default_value(true), "Apply AA (recommended when used with aspect ratio correction)")
-		("emulator.screenshot_image_type", po::value<std::string>()->default_value("bmp"), "Image file type for screenshots");
+		("emulator.screenshot_image_type", po::value<std::string>()->default_value("png"), "Image file type for screenshots");
 
 	po::options_description printer_options("Printer");
 	printer_options.add_options()
-		("printer.image_type", po::value<std::string>()->default_value("bmp"), "Image file type for printed files")
+		("printer.image_type", po::value<std::string>()->default_value("png"), "Image file type for printed files")
 		("printer.view_command", po::value<std::string>()->default_value("OPEN"), "Command to run with printed files")
 		("printer.correct_aspect_ratio", po::value<bool>()->default_value(true), "Scale up print and stretch to same aspect ratio as Loopy Seals");
 

--- a/src/sdl/options.cpp
+++ b/src/sdl/options.cpp
@@ -157,7 +157,8 @@ bool parse_config(fs::path config_path, Args& args)
 	po::options_description printer_options("Printer");
 	printer_options.add_options()
 		("printer.image_type", po::value<std::string>()->default_value("bmp"), "Image file type for printed files")
-		("printer.view_command", po::value<std::string>()->default_value("OPEN"), "Command to run with printed files");
+		("printer.view_command", po::value<std::string>()->default_value("OPEN"), "Command to run with printed files")
+		("printer.correct_aspect_ratio", po::value<bool>()->default_value(true), "Scale up print and stretch to same aspect ratio as Loopy Seals");
 
 	po::options_description options;
 	options.add(key_options).add(button_options).add(emu_options).add(printer_options);
@@ -186,6 +187,7 @@ bool parse_config(fs::path config_path, Args& args)
 		args.screenshot_image_type = imagew::parse_image_type(
 			vm["emulator.screenshot_image_type"].as<std::string>(), imagew::IMAGE_TYPE_DEFAULT
 		);
+		args.printer_correct_aspect_ratio = vm["printer.correct_aspect_ratio"].as<bool>();
 		args.printer_image_type =
 			imagew::parse_image_type(vm["printer.image_type"].as<std::string>(), imagew::IMAGE_TYPE_DEFAULT);
 		args.printer_view_command = vm["printer.view_command"].as<std::string>();

--- a/src/sdl/options.h
+++ b/src/sdl/options.h
@@ -18,7 +18,6 @@ struct Args
 	bool crop_overscan;
 	bool antialias;
 	bool verbose;
-	bool capture_mouse;
 	int int_scale = 2;
 	int screenshot_image_type;
 

--- a/src/sdl/options.h
+++ b/src/sdl/options.h
@@ -18,6 +18,7 @@ struct Args
 	bool crop_overscan;
 	bool antialias;
 	bool verbose;
+	bool capture_mouse;
 	int int_scale = 2;
 	int screenshot_image_type;
 

--- a/src/sdl/options.h
+++ b/src/sdl/options.h
@@ -23,6 +23,7 @@ struct Args
 	int screenshot_image_type;
 
 	int printer_image_type;
+	bool printer_correct_aspect_ratio;
 	std::string printer_view_command;
 };
 

--- a/src/video/video.cpp
+++ b/src/video/video.cpp
@@ -1,5 +1,5 @@
+#include <sdl/imgwriter.h>
 #include <common/bswp.h>
-#include <common/imgwriter.h>
 #include <common/wordops.h>
 #include <core/loopy_io.h>
 #include <core/memory.h>
@@ -16,7 +16,7 @@
 #include "video/render.h"
 #include "video/vdp_local.h"
 
-namespace imagew = Common::ImageWriter;
+namespace imagew = SDL::ImageWriter;
 
 namespace Video
 {


### PR DESCRIPTION
* Scales up and aspect corrects prints to 1024x896 8:7 with nearest neighbour (looks actually quite good)
* Adds JPG and PNG save methods using SDL2-image, new default to PNG
* Screenshots go through SDL, capturing whatever scaling/aspect correction/antialiasing options currently used
* Updates CI builders to latest